### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ No data DEMO screenshot
 ![](screenshots/GridBuilder_2.jpg)
 Online app screenshot
 
-##Module:
+## Module:
 
  **GridBuilderLib**: GridBuilder Library
  
  **GridBuilderDemo**: Application Demo
 
-##Library Structure:
+## Library Structure:
 
   **/calculator**: The calculator of layout
   
@@ -30,14 +30,14 @@ Online app screenshot
   
   **IGridItemView**: The child view of GridLayout should implement this interface
 
-##Feature:
+## Feature:
 
  1. Support Android non-touch devices(Box, TV), support child view focused animation
  2. Support custom child view position calculator(provided horizontal layout calculator)
  3. Support vertical and horizontal stretch(need to nested ScrollView or HorizontalScrollView out of GridLayout)
  4. Support for dynamic reflection
     
-##Instructions:
+## Instructions:
 
 1.Placed the GridLayout in layout.xml
 
@@ -133,13 +133,13 @@ Online app screenshot
             .build();
 
 
-##To be improved:
+## To be improved:
 
 1. Dynamic focus style
 2. Recycling / child view reuse
 3. Friendly adapter design pattern
 
-##Support：
+## Support：
 Please feel free to [report bugs](https://github.com/Eason90/GridBuilder/issues) or ask for help via email.
 
 Email: easonx1990@gmail.com

--- a/README_CN_SIMPLIFIED.md
+++ b/README_CN_SIMPLIFIED.md
@@ -6,13 +6,13 @@ GridBuilder是将Android原生容器GridLayout进行封装，只需在指定Grid
 ![](screenshots/GridBuilder_2.jpg)
 商用截图
 
-##Module：
+## Module：
 
  **GridBuilderLib**：GridBuilder Library
  
  **GridBuilderDemo**：应用Demo
 
-##Lib结构：
+## Lib结构：
 
   **/calculator**：动态布局计算器
   
@@ -26,14 +26,14 @@ GridBuilder是将Android原生容器GridLayout进行封装，只需在指定Grid
   
   **IGridItemView**：GridLayout中的Child View必须实现其接口
 
-##特点：
+## 特点：
 
  1. 全面支持Android非触屏端(盒子、TV)，支持焦点放大动效
  2. 支持自定义布局算法(默认自带横向布局Calculator)
  3. 支持横纵向延伸(需在GridLayout外套ScrollView/HorizontalScrollView)
  4. 支持动态倒影
     
-##使用方法：
+## 使用方法：
 
 1.在layout.xml中放置GridLayout
 
@@ -129,13 +129,13 @@ GridBuilder是将Android原生容器GridLayout进行封装，只需在指定Grid
             .build();
 
 
-##待完善：
+## 待完善：
 
 1. 动态焦点样式
 2. 资源回收/childView复用
 3. 更友好的adapter模式
 
-##支持：
+## 支持：
 任何问题可以在项目中[提交bug报告](https://github.com/Eason90/GridBuilder/issues)，也可以发送邮件以寻求帮助。
 
 Email: easonx1990@gmail.com

--- a/README_CN_TRADITIONAL.md
+++ b/README_CN_TRADITIONAL.md
@@ -6,13 +6,13 @@ GridBuilder是將Android原生容器GridLayout進行封裝，只需在指定Grid
 ![](screenshots/GridBuilder_2.jpg)
 商用截圖
 
-##Module：
+## Module：
 
  **GridBuilderLib**：GridBuilder Library
 
  **GridBuilderDemo**：應用Demo
 
-##Lib結構：
+## Lib結構：
 
   **/calculator**：動態布局計算器
 
@@ -26,14 +26,14 @@ GridBuilder是將Android原生容器GridLayout進行封裝，只需在指定Grid
 
   **IGridItemView**：GridLayout中的Child View必須實現其接口
 
-##特點：
+## 特點：
 
  1. 全面支持Android非觸屏端(盒子、TV)，支持焦點放大動效
  2. 支持自定義布局算法(默認自帶橫向布局Calculator)
  3. 支持橫縱向延伸(需在GridLayout外套ScrollView/HorizontalScrollView)
  4. 支持動態倒影
 
-##使用方法：
+## 使用方法：
 
 1.在layout.xml中放置GridLayout
 
@@ -129,13 +129,13 @@ GridBuilder是將Android原生容器GridLayout進行封裝，只需在指定Grid
             .build();
 
 
-##待完善：
+## 待完善：
 
 1. 動態焦點樣式
 2. 資源回收/childView復用
 3. 更友好的adapter模式
 
-##支持：
+## 支持：
 任何問題可以在項目中[提交bug報告](https://github.com/Eason90/GridBuilder/issues)，也可以發送郵件以尋求幫助。
 
 Email: easonx1990@gmail.com


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
